### PR TITLE
init: execute a proper initializer for the userns case

### DIFF
--- a/integration/exec_test.go
+++ b/integration/exec_test.go
@@ -12,6 +12,17 @@ import (
 )
 
 func TestExecPS(t *testing.T) {
+	testExecPS(t, false)
+}
+
+func TestUsernsExecPS(t *testing.T) {
+	if _, err := os.Stat("/proc/self/ns/user"); os.IsNotExist(err) {
+		t.Skip("userns is unsupported")
+	}
+	testExecPS(t, true)
+}
+
+func testExecPS(t *testing.T, userns bool) {
 	if testing.Short() {
 		return
 	}
@@ -21,6 +32,12 @@ func TestExecPS(t *testing.T) {
 	}
 	defer remove(rootfs)
 	config := newTemplateConfig(rootfs)
+	if userns {
+		config.UidMappings = []configs.IDMap{{0, 0, 1000}}
+		config.GidMappings = []configs.IDMap{{0, 0, 1000}}
+		config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
+	}
+
 	buffers, exitCode, err := runContainer(config, "", "ps")
 	if err != nil {
 		t.Fatalf("%s: %s", buffers, err)

--- a/linux_container.go
+++ b/linux_container.go
@@ -141,9 +141,11 @@ func (c *linuxContainer) newInitProcess(p *Process, cmd *exec.Cmd, parentPipe, c
 		if cmd.SysProcAttr.Credential == nil {
 			cmd.SysProcAttr.Credential = &syscall.Credential{}
 		}
+		cmd.Env = append(cmd.Env, "_LIBCONTAINER_INITTYPE=userns")
+	} else {
+		cmd.Env = append(cmd.Env, "_LIBCONTAINER_INITTYPE=standard")
 	}
 	cmd.SysProcAttr.Cloneflags = cloneFlags
-	cmd.Env = append(cmd.Env, "_LIBCONTAINER_INITTYPE=standard")
 	return &initProcess{
 		cmd:        cmd,
 		childPipe:  childPipe,

--- a/linux_rootfs.go
+++ b/linux_rootfs.go
@@ -46,13 +46,9 @@ func setupRootfs(config *configs.Config) (err error) {
 	if err := setupPtmx(config); err != nil {
 		return err
 	}
-	uid, err := config.HostUID()
-	if err != nil {
-		return err
-	}
 	// stdin, stdout and stderr could be pointing to /dev/null from parent namespace.
 	// Re-open them inside this namespace.
-	if uid == 0 {
+	if !config.Namespaces.Contains(configs.NEWUSER) {
 		if err := reOpenDevNull(config.Rootfs); err != nil {
 			return err
 		}

--- a/linux_userns_sidecar_init.go
+++ b/linux_userns_sidecar_init.go
@@ -26,7 +26,7 @@ func (l *linuxUsernsSideCar) Init() error {
 	}
 	label.Init()
 	// InitializeMountNamespace() can be executed only for a new mount namespace
-	if l.config.Config.Namespaces.Contains(configs.NEWNET) {
+	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
 		if err := setupRootfs(l.config.Config); err != nil {
 			return err
 		}


### PR DESCRIPTION
I suggested to check userns here:
https://github.com/docker/libcontainer/pull/360
